### PR TITLE
libluna-service2/base: Replace NULL check with LSErrorIsSet

### DIFF
--- a/src/libluna-service2/base.c
+++ b/src/libluna-service2/base.c
@@ -800,7 +800,7 @@ LSErrorLogDefault(const char *message_id, LSError *lserror)
 void
 LSErrorFree(LSError *lserror)
 {
-    if (lserror)
+    if (LSErrorIsSet(lserror))
     {
         LSERROR_CHECK_MAGIC(lserror);
         g_free(lserror->message);


### PR DESCRIPTION
Currently LSErrorFree is only checking whether the argument is NULL and
g_free could be called even though LSError is unset.
Also, the current expression in if is unclear and could be blurred.

Calling LSErrorIsSet is more clear and improves readability.