### PR TITLE
Add LS_RETURN_*IF_FAIL macros

### DIFF
--- a/src/libluna-service2/error.h
+++ b/src/libluna-service2/error.h
@@ -68,6 +68,31 @@ do {                    \
     }                    \
 } while (0)
 
+#define LS_RETURN_IF_FAIL(_expr) \
+do {                             \
+    if (!(_expr)) {              \
+        LOG_LS_ERROR(MSGID_LS_RETURN_IF_FAIL, 4,          \
+                     PMLOGKS("COND", #_expr),             \
+                     PMLOGKS("FUNC", __FUNCTION__),       \
+                     PMLOGKS("FILE" , LS__FILE__BASENAME),\
+                     PMLOGKFV("LINE", "%d", __LINE__),    \
+                     "%s: failed", #_expr);               \
+        return;          \
+    }                    \
+} while (0)
+
+#define LS_RETURN_VAL_IF_FAIL(_expr, _val) \
+do {                                       \
+    if (!(_expr)) {                        \
+        LOG_LS_ERROR(MSGID_LS_RETURN_IF_FAIL, 4,          \
+                     PMLOGKS("COND", #_expr),             \
+                     PMLOGKS("FUNC", __FUNCTION__),       \
+                     PMLOGKS("FILE" , LS__FILE__BASENAME),\
+                     PMLOGKFV("LINE", "%d", __LINE__),    \
+                     "%s: failed", #_expr);               \
+        return _val;     \
+    }                    \
+} while (0)
 
 #define LS_MAGIC(typestring) \
 (  ( ((typestring)[sizeof(typestring)*7/8] << 24) | \

--- a/src/libluna-service2/log_ids.h
+++ b/src/libluna-service2/log_ids.h
@@ -142,6 +142,7 @@
 #define MSGID_LS_QUEUE_ERROR                    "LS_QUEUE"              /** Message queue error */
 #define MSGID_LS_REPLY_TOK                      "LS_REPLY_TOK"          /** Getting reply token for message type */
 #define MSGID_LS_REQUEST_NAME                   "LS_REQ_NAME"           /** Error during name request */
+#define MSGID_LS_RETURN_IF_FAIL                 "LS_RETURN_IF_FAIL"     /** Return value if expression is False */
 #define MSGID_LS_SEND_ERROR                     "LS_SEND"               /** Sending error */
 #define MSGID_LS_SERIAL_ERROR                   "LS_SERIAL"             /** Serial map error */
 #define MSGID_LS_SHARED_MEMORY_ERR              "LS_SHM"                /** Shared memory error*/


### PR DESCRIPTION
These macros are
- LS_RETURN_IF_FAIL(_expr)
- LS_RETURN_VAL_IF_FAIL(_expr)

They are useful when developers want to return a value(includes void) on failure of the _expr.