### PR TITLE
Add NULL check for the methods of SubscriptionIter

### DIFF
--- a/src/libluna-service2/error.h
+++ b/src/libluna-service2/error.h
@@ -68,6 +68,31 @@ do {                    \
     }                    \
 } while (0)
 
+#define LS_RETURN_IF_FAIL(_expr) \
+do {                             \
+    if (!(_expr)) {              \
+        LOG_LS_ERROR(MSGID_LS_RETURN_IF_FAIL, 4,          \
+                     PMLOGKS("COND", #_expr),             \
+                     PMLOGKS("FUNC", __FUNCTION__),       \
+                     PMLOGKS("FILE" , LS__FILE__BASENAME),\
+                     PMLOGKFV("LINE", "%d", __LINE__),    \
+                     "%s: failed", #_expr);               \
+        return;          \
+    }                    \
+} while (0)
+
+#define LS_RETURN_VAL_IF_FAIL(_expr, _val) \
+do {                                       \
+    if (!(_expr)) {                        \
+        LOG_LS_ERROR(MSGID_LS_RETURN_IF_FAIL, 4,          \
+                     PMLOGKS("COND", #_expr),             \
+                     PMLOGKS("FUNC", __FUNCTION__),       \
+                     PMLOGKS("FILE" , LS__FILE__BASENAME),\
+                     PMLOGKFV("LINE", "%d", __LINE__),    \
+                     "%s: failed", #_expr);               \
+        return _val;     \
+    }                    \
+} while (0)
 
 #define LS_MAGIC(typestring) \
 (  ( ((typestring)[sizeof(typestring)*7/8] << 24) | \

--- a/src/libluna-service2/log_ids.h
+++ b/src/libluna-service2/log_ids.h
@@ -142,6 +142,7 @@
 #define MSGID_LS_QUEUE_ERROR                    "LS_QUEUE"              /** Message queue error */
 #define MSGID_LS_REPLY_TOK                      "LS_REPLY_TOK"          /** Getting reply token for message type */
 #define MSGID_LS_REQUEST_NAME                   "LS_REQ_NAME"           /** Error during name request */
+#define MSGID_LS_RETURN_IF_FAIL                 "LS_RETURN_IF_FAIL"     /** Return value if expression is False */
 #define MSGID_LS_SEND_ERROR                     "LS_SEND"               /** Sending error */
 #define MSGID_LS_SERIAL_ERROR                   "LS_SERIAL"             /** Serial map error */
 #define MSGID_LS_SHARED_MEMORY_ERR              "LS_SHM"                /** Shared memory error*/

--- a/src/libluna-service2/subscription.c
+++ b/src/libluna-service2/subscription.c
@@ -1064,7 +1064,11 @@ LSSubscriptionAcquire(LSHandle *sh, const char *key,
 void
 LSSubscriptionRelease(LSSubscriptionIter *iter)
 {
-    GSList *seen_iter = iter->seen_messages;
+    GSList *seen_iter;
+
+    LS_RETURN_IF_FAIL(iter != NULL);
+
+    seen_iter = iter->seen_messages;
     while (seen_iter)
     {
         LSMessage *msg = (LSMessage*)seen_iter->data;
@@ -1090,6 +1094,8 @@ LSSubscriptionRelease(LSSubscriptionIter *iter)
 bool
 LSSubscriptionHasNext(LSSubscriptionIter *iter)
 {
+    LS_RETURN_VAL_IF_FAIL(iter != NULL, false);
+
     if (!iter->tokens)
     {
         return false;
@@ -1112,6 +1118,8 @@ LSSubscriptionNext(LSSubscriptionIter *iter)
 {
     _Subscription *subs = NULL;
     LSMessage *message = NULL;
+
+    LS_RETURN_VAL_IF_FAIL(iter != NULL, NULL);
 
     iter->index++;
     const char *tok = _SubListGet(iter->tokens, iter->index);
@@ -1143,7 +1151,11 @@ LSSubscriptionNext(LSSubscriptionIter *iter)
 void
 LSSubscriptionRemove(LSSubscriptionIter *iter)
 {
-    const char *tok = _SubListGet(iter->tokens, iter->index);
+    const char *tok;
+
+    LS_RETURN_IF_FAIL(iter != NULL);
+
+    tok = _SubListGet(iter->tokens, iter->index);
     if (tok)
     {
         _CatalogRemoveToken(iter->catalog, tok, false);


### PR DESCRIPTION
If NULL is passed to the parameter, iter, program would be aborted at runtime.
Aborting a program is necessary by using LS_ASSERT from time to time, but
it seems not to fit on those methods.
Instead of assert, they return if the parameter is NULL.

In this PR, two files, error and subscription were changed and two macros, LS_RETURN_*IF_FAIL added.